### PR TITLE
Remove Promise-wrapped params

### DIFF
--- a/src/app/api/workflow/[id]/input/route.ts
+++ b/src/app/api/workflow/[id]/input/route.ts
@@ -4,10 +4,10 @@ import { Database } from '@/types/supabase'
 
 export async function POST(
   request: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   try {
-    const { id } = await params
+    const { id } = params
     const url = new URL(request.url)
     const version = url.searchParams.get('version')
 

--- a/src/app/api/workflow/[id]/output/route.ts
+++ b/src/app/api/workflow/[id]/output/route.ts
@@ -226,13 +226,13 @@ function processWorkflow(workflow: Workflow, inputData: Json) {
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   try {
     const { searchParams } = new URL(request.url)
     const inputId = searchParams.get('input_id')
     const version = searchParams.get('version')
-    const { id } = await params
+    const { id } = params
 
     if (!id) {
       return NextResponse.json(

--- a/src/app/api/workflow/[id]/route.ts
+++ b/src/app/api/workflow/[id]/route.ts
@@ -4,10 +4,10 @@ import { Database } from '@/types/supabase'
 
 export async function PATCH(
   request: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   try {
-    const { id } = await params
+    const { id } = params
     const body = await request.json()
     const shouldCreateVersion = body.create_version === true
     delete body.create_version
@@ -72,10 +72,10 @@ export async function PATCH(
 
 export async function DELETE(
   request: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   try {
-    const { id } = await params
+    const { id } = params
 
     if (!id) {
       return NextResponse.json(
@@ -112,10 +112,10 @@ export async function DELETE(
 
 export async function GET(
   request: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   try {
-    const { id } = await params
+    const { id } = params
 
     if (!id) {
       return NextResponse.json(

--- a/src/app/api/workflow/[id]/version/[version]/route.ts
+++ b/src/app/api/workflow/[id]/version/[version]/route.ts
@@ -7,10 +7,10 @@ const supabase = createClient(supabaseUrl, supabaseKey)
 
 export async function GET(
   request: Request,
-  { params }: { params: Promise<{ id: string; version: string }> }
+  { params }: { params: { id: string; version: string } }
 ) {
   try {
-    const { id, version } = await params
+    const { id, version } = params
 
     // Get current workflow to check latest version
     const { data: currentWorkflow, error: currentError } = await supabase

--- a/src/app/api/workflow/[id]/versions/route.ts
+++ b/src/app/api/workflow/[id]/versions/route.ts
@@ -7,10 +7,10 @@ const supabase = createClient(supabaseUrl, supabaseKey)
 
 export async function GET(
   request: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   try {
-    const { id } = await params
+    const { id } = params
 
     // Check if workflow exists
     const { data: workflow, error: workflowError } = await supabase

--- a/src/app/playground/[id]/live/page.tsx
+++ b/src/app/playground/[id]/live/page.tsx
@@ -67,12 +67,12 @@ async function getLiveData(id: string) {
 }
 
 interface PageProps {
-  params: Promise<{ id: string }>
+  params: { id: string }
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }
 
 export default async function LivePage({ params, searchParams }: PageProps) {
-  const { id } = await params
+  const { id } = params
   const { version } = await searchParams as { version?: string }
   const workflow = await getWorkflow(id, version)
   const inputs = await getLiveData(id)
@@ -82,4 +82,4 @@ export default async function LivePage({ params, searchParams }: PageProps) {
   }
 
   return <LivePageContent workflow={workflow} inputs={inputs} />
-} 
+}

--- a/src/app/playground/[id]/page.tsx
+++ b/src/app/playground/[id]/page.tsx
@@ -3,13 +3,13 @@ import { getWorkflow } from '@/app/actions'
 import { WorkflowPlayground } from '@/components/workflow-playground'
 
 type PageProps = {
-  params: Promise<{
+  params: {
     id: string
-  }>
+  }
 }
 
 export default async function Page({ params }: PageProps) {
-  const { id } = await params
+  const { id } = params
   
   try {
     const workflow = await getWorkflow(id)
@@ -21,4 +21,4 @@ export default async function Page({ params }: PageProps) {
     console.error('Error loading workflow:', error)
     return notFound()
   }
-} 
+}


### PR DESCRIPTION
## Summary
- refactor page and API route params to be synchronous objects
- drop redundant `await` calls when reading params

## Testing
- `npm run lint` *(fails: `next` not found)*